### PR TITLE
Dev

### DIFF
--- a/lib/controllers/commands/set_page_command.dart
+++ b/lib/controllers/commands/set_page_command.dart
@@ -3,6 +3,6 @@ import 'package:wvems_protocols/controllers/commands/abstract_command.dart';
 class SetPageCommand extends AbstractCommand {
   @override
   Future<void> execute({int? pageIndex}) async {
-    await pdfStateController.rxPdfController?.value.setPage(pageIndex ?? 0);
+    await pdfStateController.setPdfPage(pageIndex);
   }
 }

--- a/lib/controllers/pdf_state_controller.dart
+++ b/lib/controllers/pdf_state_controller.dart
@@ -80,12 +80,12 @@ class PdfStateController extends GetxController with WidgetsBindingObserver {
     final f = await _pdfService.fromAsset(assetPath, 'active.pdf');
     pathPDF = f.path;
     print('pdf loaded: $pathPDF');
-    _resetPdfUI();
+    resetPdfUI();
     _createNewPdfController();
     return f;
   }
 
-  void _resetPdfUI() {
+  void resetPdfUI() {
     // set new UniqueKey, which triggers a UI redraw
     // UniqueKey is most important w/ Android redraws
     pdfViewerKey = UniqueKey();

--- a/lib/controllers/pdf_state_controller.dart
+++ b/lib/controllers/pdf_state_controller.dart
@@ -85,11 +85,13 @@ class PdfStateController extends GetxController with WidgetsBindingObserver {
     return f;
   }
 
-  void resetPdfUI() {
+  void resetPdfUI({bool goHome = true}) {
     // set new UniqueKey, which triggers a UI redraw
     // UniqueKey is most important w/ Android redraws
     pdfViewerKey = UniqueKey();
-    currentPage.value = 0;
+    if (goHome) {
+      currentPage.value = 0;
+    }
   }
 
   /// **********************************************************

--- a/lib/ui/views/home/body/home_pdf_screen.dart
+++ b/lib/ui/views/home/body/home_pdf_screen.dart
@@ -4,48 +4,56 @@ import 'package:get/get.dart';
 import 'package:wvems_protocols/controllers/controllers.dart';
 
 class HomePdfScreen extends StatelessWidget {
-  const HomePdfScreen({Key? key, required this.path}) : super(key: key);
+  HomePdfScreen({Key? key, required this.path}) : super(key: key);
 
   final String path;
+  final PdfStateController controller = Get.find();
 
   @override
   Widget build(BuildContext context) {
-    final PdfStateController controller = Get.find();
-
-    return Obx(
-      () => Container(
-        child:
-            // only display the PDFView screen if the 'isReady' tag is true
-            controller.errorMessage.value.isEmpty
-                ? !controller.isReady.value
-                    ? PDFView(
-                        filePath: path,
-                        // required for Android
-                        key: controller.pdfViewerKey,
-                        enableSwipe: true,
-                        swipeHorizontal: false,
-                        autoSpacing: true,
-                        pageFling: true,
-                        pageSnap: true,
-                        defaultPage: controller.currentPage.value,
-                        fitPolicy: FitPolicy.WIDTH,
-                        // if set to true, the link is handled in flutter
-                        preventLinkNavigation: false,
-                        onRender: (intArg) => controller.onPdfRender,
-                        onError: controller.onPdfError,
-                        onPageError: (intArg, dynamicArg) =>
-                            controller.onPdfPageError,
-                        onViewCreated: controller.onPdfViewCreated,
-                        onLinkHandler: (stringArg) =>
-                            controller.onPdfLinkHandler,
-                        onPageChanged: (int1Arg, int2Arg) =>
-                            controller.onPdfPageChanged,
-                      )
-                    : const Center(child: CircularProgressIndicator())
-                : Center(
-                    child: Text(controller.errorMessage.value),
-                  ),
-      ),
+    controller.resetPdfUI();
+    return OrientationBuilder(
+      builder: (context, orientation) {
+        if (orientation != controller.currentOrientation) {
+          controller.currentOrientation = orientation;
+          controller.resetPdfUI();
+        }
+        return Obx(
+          () => Container(
+            child:
+                // only display the PDFView screen if the 'isReady' tag is true
+                controller.errorMessage.value.isEmpty
+                    ? !controller.isReady.value
+                        ? PDFView(
+                            filePath: path,
+                            // required for Android
+                            key: controller.pdfViewerKey,
+                            enableSwipe: true,
+                            swipeHorizontal: false,
+                            autoSpacing: true,
+                            pageFling: true,
+                            pageSnap: true,
+                            defaultPage: controller.currentPage.value,
+                            fitPolicy: FitPolicy.BOTH,
+                            // if set to true, the link is handled in flutter
+                            preventLinkNavigation: false,
+                            onRender: (intArg) => controller.onPdfRender,
+                            onError: controller.onPdfError,
+                            onPageError: (intArg, dynamicArg) =>
+                                controller.onPdfPageError,
+                            onViewCreated: controller.onPdfViewCreated,
+                            onLinkHandler: (stringArg) =>
+                                controller.onPdfLinkHandler,
+                            onPageChanged: (int1Arg, int2Arg) =>
+                                controller.onPdfPageChanged,
+                          )
+                        : const Center(child: CircularProgressIndicator())
+                    : Center(
+                        child: Text(controller.errorMessage.value),
+                      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/ui/views/home/body/home_pdf_screen.dart
+++ b/lib/ui/views/home/body/home_pdf_screen.dart
@@ -16,7 +16,7 @@ class HomePdfScreen extends StatelessWidget {
       builder: (context, orientation) {
         if (orientation != controller.currentOrientation) {
           controller.currentOrientation = orientation;
-          controller.resetPdfUI();
+          controller.resetPdfUI(goHome: false);
         }
         return Obx(
           () => Container(


### PR DESCRIPTION
Made resetPdfUI public.

Called it each time HomePdfScreen is rebuilt.

Added an Orientation builder to HomePdfScreen, when the orientation changes, it also calls resetPdfUI.

Added a boolean argument to resetPdfUI. Normally it will return to the first page of the pdf document, but if you pass it false, it will skip that (so you can maintain the page you're on, if all you've done is rotate your screen).